### PR TITLE
Add sepolicy for mediasdk codec2.0

### DIFF
--- a/codec2/msdk-codec2/codec2_hal_default.te
+++ b/codec2/msdk-codec2/codec2_hal_default.te
@@ -1,0 +1,12 @@
+type codec2_hal_default, domain;
+
+type codec2_hal_default_exec, exec_type, file_type, vendor_file_type;
+
+init_daemon_domain(codec2_hal_default)
+
+vndbinder_use(codec2_hal_default)
+
+get_prop(codec2_hal_default, hwservicemanager_prop)
+
+allow codec2_hal_default hwservicemanager:binder call;
+allow codec2_hal_default tombstoned_crash_socket:sock_file write;

--- a/codec2/msdk-codec2/file_contexts
+++ b/codec2/msdk-codec2/file_contexts
@@ -1,0 +1,1 @@
+/vendor/bin/hw/hardware\.intel\.media\.c2@1\.0-service u:object_r:codec2_hal_default_exec:s0


### PR DESCRIPTION
Add sepolicy for hardware.intel.media.c2@1.0-service.

Tracked-On: OAM-100150
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>